### PR TITLE
Adding SearchByNameAsync method and fix to LISTing contacts that have multiple companies listed

### DIFF
--- a/src/DBA.FreshdeskSharp/DBA.FreshdeskSharp/DBA.FreshdeskSharp.csproj
+++ b/src/DBA.FreshdeskSharp/DBA.FreshdeskSharp/DBA.FreshdeskSharp.csproj
@@ -14,6 +14,8 @@
     <PackageLicenseUrl>https://github.com/dbasoftware/freshdesksharp/blob/master/LICENSE</PackageLicenseUrl>
     <PackageId>FreshdeskSharp</PackageId>
     <Product>FreshdeskSharp</Product>
+    <AssemblyVersion>0.2.22026.1329</AssemblyVersion>
+    <FileVersion>0.2.22026.1329</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='net45'">
     <AssemblyTitle>FreshdeskSharp .NET 4.5</AssemblyTitle>

--- a/src/DBA.FreshdeskSharp/DBA.FreshdeskSharp/DBA.FreshdeskSharp.csproj
+++ b/src/DBA.FreshdeskSharp/DBA.FreshdeskSharp/DBA.FreshdeskSharp.csproj
@@ -14,8 +14,8 @@
     <PackageLicenseUrl>https://github.com/dbasoftware/freshdesksharp/blob/master/LICENSE</PackageLicenseUrl>
     <PackageId>FreshdeskSharp</PackageId>
     <Product>FreshdeskSharp</Product>
-    <AssemblyVersion>0.2.22026.1329</AssemblyVersion>
-    <FileVersion>0.2.22026.1329</FileVersion>
+    <AssemblyVersion>0.2.22080.1147</AssemblyVersion>
+    <FileVersion>0.2.22080.1147</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='net45'">
     <AssemblyTitle>FreshdeskSharp .NET 4.5</AssemblyTitle>

--- a/src/DBA.FreshdeskSharp/DBA.FreshdeskSharp/Endpoints/FreshdeskCompaniesEndpoint.cs
+++ b/src/DBA.FreshdeskSharp/DBA.FreshdeskSharp/Endpoints/FreshdeskCompaniesEndpoint.cs
@@ -97,6 +97,17 @@ namespace DBA.FreshdeskSharp.Endpoints
             }
         }
 
+        public async Task<FreshdeskCompanySearchByNameResults> SearchByNameAsync(string name)
+        {
+            var query = $"?name=\"{WebUtility.UrlEncode(name)}\"";
+            var requestUri = $"{_apiBaseUri}/companies/autocomplete{query}";
+            using (var response = await _httpClient.GetAsync(requestUri).ConfigureAwait(false))
+            {
+                return await GetResponseAsync<FreshdeskCompanySearchByNameResults>(response).ConfigureAwait(false);
+            }
+        }
+
+
         public async Task<List<FreshdeskCompanyField>> GetFieldsAsync()
         {
             var requestUri = $"{_apiBaseUri}/company_fields";

--- a/src/DBA.FreshdeskSharp/DBA.FreshdeskSharp/Endpoints/FreshdeskContactsEndpoint.cs
+++ b/src/DBA.FreshdeskSharp/DBA.FreshdeskSharp/Endpoints/FreshdeskContactsEndpoint.cs
@@ -40,6 +40,23 @@ namespace DBA.FreshdeskSharp.Endpoints
             }
         }
 
+
+        public async Task<FreshdeskContactSearchResults<FreshdeskCustomFields>> SearchAsync(string searchQuery)
+        {
+            return await SearchAsync<FreshdeskCustomFields>(searchQuery).ConfigureAwait(false);
+        }
+
+        public async Task<FreshdeskContactSearchResults<TCustomFieldObject>> SearchAsync<TCustomFieldObject>(string searchQuery) where TCustomFieldObject : class
+        {
+            var query = $"?query=\"{WebUtility.UrlEncode(searchQuery)}\"";
+            var requestUri = $"{_apiBaseUri}/search/contacts{query}";
+            using (var response = await _httpClient.GetAsync(requestUri).ConfigureAwait(false))
+            {
+                return await GetResponseAsync<FreshdeskContactSearchResults<TCustomFieldObject>>(response).ConfigureAwait(false);
+            }
+        }
+
+
         public async Task<FreshdeskContact<FreshdeskCustomFields>> GetAsync(ulong id)
         {
             return await GetAsync<FreshdeskCustomFields>(id).ConfigureAwait(false);

--- a/src/DBA.FreshdeskSharp/DBA.FreshdeskSharp/Endpoints/FreshdeskContactsEndpoint.cs
+++ b/src/DBA.FreshdeskSharp/DBA.FreshdeskSharp/Endpoints/FreshdeskContactsEndpoint.cs
@@ -35,7 +35,7 @@ namespace DBA.FreshdeskSharp.Endpoints
             var requestUri = $"{_apiBaseUri}/contacts{query}";
             using (var response = await _httpClient.GetAsync(requestUri).ConfigureAwait(false))
             {
-                var result = await GetResponseAsync<List<FreshdeskContactInternal<TCustomFieldObject>>>(response).ConfigureAwait(false);
+                var result = await GetResponseAsync<List<FreshdeskContactFromListInternal<TCustomFieldObject>>>(response).ConfigureAwait(false);
                 return result.Select(contact => contact.ToContact()).ToList();
             }
         }

--- a/src/DBA.FreshdeskSharp/DBA.FreshdeskSharp/Endpoints/FreshdeskTicketsEndpoint.cs
+++ b/src/DBA.FreshdeskSharp/DBA.FreshdeskSharp/Endpoints/FreshdeskTicketsEndpoint.cs
@@ -51,6 +51,30 @@ namespace DBA.FreshdeskSharp.Endpoints
             }
         }
 
+
+        public async Task<FreshdeskConversationReply> CreateReplyAsync(ulong ticketid, FreshdeskConversationReply reply)
+        {
+            var requestJson = JsonConvert.SerializeObject(reply, _serializationSettings);
+            var requestUri = $"{_apiBaseUri}/tickets/{ticketid}/reply";
+            using (var requestContent = new StringContent(requestJson, Encoding.UTF8, "application/json"))
+            using (var response = await _httpClient.PostAsync(requestUri, requestContent).ConfigureAwait(false))
+            {
+                return await GetResponseAsync<FreshdeskConversationReply>(response).ConfigureAwait(false);
+            }
+        }
+
+
+        public async Task<FreshdeskNoteResponse> CreateNoteAsync(ulong ticketid, FreshdeskNote note)
+        {
+            var requestJson = JsonConvert.SerializeObject(note, _serializationSettings);
+            var requestUri = $"{_apiBaseUri}/tickets/{ticketid}/notes";
+            using (var requestContent = new StringContent(requestJson, Encoding.UTF8, "application/json"))
+            using (var response = await _httpClient.PostAsync(requestUri, requestContent).ConfigureAwait(false))
+            {
+                return await GetResponseAsync<FreshdeskNoteResponse>(response).ConfigureAwait(false);
+            }
+        }
+
         public async Task<List<FreshdeskTicket<FreshdeskCustomFields>>> GetListAsync(FreshdeskTicketListOptions options)
         {
             return await GetListAsync<FreshdeskCustomFields>(options).ConfigureAwait(false);
@@ -92,8 +116,8 @@ namespace DBA.FreshdeskSharp.Endpoints
             return await SearchAsync<TCustomFieldObject>(searchQueryExp).ConfigureAwait(false);
         }
 
-        public async Task<FreshdeskTicketSearchResults<TCustomFieldObject>> SearchAsync<TCustomFieldObject, TTicketQueryFields>(Expression<Func<TTicketQueryFields, bool>> searchQuery) 
-            where TTicketQueryFields : IFreshdeskTicketQuery 
+        public async Task<FreshdeskTicketSearchResults<TCustomFieldObject>> SearchAsync<TCustomFieldObject, TTicketQueryFields>(Expression<Func<TTicketQueryFields, bool>> searchQuery)
+            where TTicketQueryFields : IFreshdeskTicketQuery
             where TCustomFieldObject : class
         {
             var searchQueryExp = FreshdeskTicketSearchQueryBuilder.Build(searchQuery);

--- a/src/DBA.FreshdeskSharp/DBA.FreshdeskSharp/Models/FreshdeskCompanySearchByNameResults.cs
+++ b/src/DBA.FreshdeskSharp/DBA.FreshdeskSharp/Models/FreshdeskCompanySearchByNameResults.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+
+namespace DBA.FreshdeskSharp.Models
+{
+
+    public class FreshdeskCompanySearchByNameItem
+    {
+        public ulong Id { get; set; }
+        public string Name { get; set; }
+
+    }
+
+
+    public class FreshdeskCompanySearchByNameResults
+    {
+        public FreshdeskCompanySearchByNameResults()
+        {
+            Companies = new List<FreshdeskCompanySearchByNameItem>();
+        }
+
+        public List<FreshdeskCompanySearchByNameItem> Companies { get; }
+    }
+}

--- a/src/DBA.FreshdeskSharp/DBA.FreshdeskSharp/Models/FreshdeskContactSearchResults.cs
+++ b/src/DBA.FreshdeskSharp/DBA.FreshdeskSharp/Models/FreshdeskContactSearchResults.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DBA.FreshdeskSharp.Models
+{
+    public class FreshdeskContactSearchResults : FreshdeskSearchResults<FreshdeskContact<FreshdeskCustomFields>>
+    {
+    }
+
+    public class FreshdeskContactSearchResults<TCustomFieldObject> : FreshdeskSearchResults<FreshdeskContact<TCustomFieldObject>> where TCustomFieldObject : class
+    {
+    }
+}

--- a/src/DBA.FreshdeskSharp/DBA.FreshdeskSharp/Models/FreshdeskConversationReply.cs
+++ b/src/DBA.FreshdeskSharp/DBA.FreshdeskSharp/Models/FreshdeskConversationReply.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace DBA.FreshdeskSharp.Models
+{
+    public class FreshdeskConversationReply
+    {
+        public FreshdeskConversationReply()
+        {
+            Attachments = new List<object>();
+            CcEmails = new List<string>();
+            BccEmails = new List<string>();
+        }
+
+
+        public string Body { get; set; }
+
+        public List<object> Attachments { get; }
+
+        [JsonProperty("from_email")]
+        public string FromEmail { get; set; }
+
+
+
+        [JsonProperty("cc_emails")]
+        public List<string> CcEmails { get; }
+
+        [JsonProperty("bcc_emails")]
+        public List<string> BccEmails { get; }
+
+
+
+        [JsonProperty("user_id")]
+        public ulong UserId { get; set; }
+
+    }
+
+    public class FreshdeskConversationReplyResponse : FreshdeskConversationReply
+    {
+        public FreshdeskConversationReplyResponse() : base()
+        {
+        }
+
+        [JsonProperty("body_text")] public string BodyText { get; set; }
+
+        public ulong Id { get; set; }
+
+        [JsonProperty("ticket_id")] public ulong TicketId { get; set; }
+
+
+        [JsonProperty("created_at")] public DateTime CreatedAt { get; set; }
+
+        [JsonProperty("updated_at")] public DateTime UpdatedAt { get; set; }
+
+    }
+}

--- a/src/DBA.FreshdeskSharp/DBA.FreshdeskSharp/Models/FreshdeskNote.cs
+++ b/src/DBA.FreshdeskSharp/DBA.FreshdeskSharp/Models/FreshdeskNote.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace DBA.FreshdeskSharp.Models
+{
+    public class FreshdeskNote
+    {
+        public FreshdeskNote()
+        {
+            Attachments = new List<object>();
+            NotifyEmails = new List<string>();
+
+            IsPrivate = true;
+        }
+        public List<object> Attachments { get; }
+
+
+        public string Body { get; set; }
+
+        public bool Incoming { get; set; }
+
+        [JsonProperty("private")]
+        public bool IsPrivate { get; set; }
+
+
+        [JsonProperty("notify_emails")]
+        public List<string> NotifyEmails { get; }
+
+        [JsonProperty("user_id")]
+        public ulong UserId { get; set; }
+
+    }
+
+    public class FreshdeskNoteResponse : FreshdeskNote
+    {
+
+        public FreshdeskNoteResponse() : base()
+        {
+            NotifiedTo = new List<string>();
+
+        }
+
+        [JsonProperty("body_text")]
+        public string BodyText { get; set; }
+
+        public ulong Id { get; set; }
+        [JsonProperty("ticket_id")]
+        public ulong TicketId { get; set; }
+
+
+        [JsonProperty("created_at")]
+        public DateTime CreatedAt { get; set; }
+
+        [JsonProperty("updated_at")]
+        public DateTime UpdatedAt { get; set; }
+
+        [JsonProperty("notified_to")]
+        public List<string> NotifiedTo { get; }
+
+
+
+
+    }
+
+}

--- a/src/DBA.FreshdeskSharp/DBA.FreshdeskSharp/Models/Internal/FreshdeskContactFromListInternal.cs
+++ b/src/DBA.FreshdeskSharp/DBA.FreshdeskSharp/Models/Internal/FreshdeskContactFromListInternal.cs
@@ -1,0 +1,12 @@
+﻿using DBA.FreshdeskSharp.Models.Abstractions;
+
+namespace DBA.FreshdeskSharp.Models.Internal
+{
+    internal class FreshdeskContactFromListInternal : FreshdeskContactFromListInternalBase<object>
+    {
+    }
+
+    internal class FreshdeskContactFromListInternal<TCustomFieldObject> : FreshdeskContactFromListInternalBase<TCustomFieldObject> where TCustomFieldObject : class
+    {
+    }
+}

--- a/src/DBA.FreshdeskSharp/DBA.FreshdeskSharp/Models/Internal/FreshdeskContactFromListInternalBase.cs
+++ b/src/DBA.FreshdeskSharp/DBA.FreshdeskSharp/Models/Internal/FreshdeskContactFromListInternalBase.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+
+namespace DBA.FreshdeskSharp.Models.Internal
+{
+    internal class FreshdeskContactFromListInternalBase<TCustomFieldObject> : IFreshdeskCustomFields<TCustomFieldObject> where TCustomFieldObject : class
+    {
+        public bool Active { get; set; }
+        public string Address { get; set; }
+        public FreshdeskAvatar Avatar { get; set; }
+        [JsonProperty("company_id")]
+        public ulong? CompanyId { get; set; }
+        [JsonProperty("view_all_tickets")]
+        public bool? ViewAllTickets { get; set; }
+        public bool Deleted { get; set; }
+        public string Description { get; set; }
+        public string Email { get; set; }
+        public ulong Id { get; set; }
+        [JsonProperty("job_title")]
+        public string JobTitle { get; set; }
+        public string Language { get; set; }
+        public string Mobile { get; set; }
+        public string Name { get; set; }
+        [JsonProperty("other_emails")]
+        public List<string> OtherEmails { get; set; }
+        public string Phone { get; set; }
+        public List<string> Tags { get; set; }
+        [JsonProperty("time_zone")]
+        public string TimeZone { get; set; }
+        [JsonProperty("twitter_id")]
+        public string TwitterId { get; set; }
+        [JsonProperty("other_companies")]
+        public List<ulong?> OtherCompanies { get; set; }
+        [JsonProperty("created_at")]
+        public DateTime CreatedAt { get; set; }
+        [JsonProperty("updated_at")]
+        public DateTime UpdatedAt { get; set; }
+        [JsonProperty("custom_fields")]
+        public TCustomFieldObject CustomFields { get; set; }
+
+        public FreshdeskContact<TCustomFieldObject> ToContact()
+        {
+            var contact = new FreshdeskContact<TCustomFieldObject>
+            {
+                Active = Active,
+                Address = Address,
+                Avatar = Avatar,
+                CompanyId = CompanyId ?? default(ulong),
+                ViewAllTickets = ViewAllTickets ?? default(bool),
+                Deleted = Deleted,
+                Description = Description,
+                Email = Email,
+                Id = Id,
+                JobTitle = JobTitle,
+                Language = Language,
+                Mobile = Mobile,
+                Name = Name,
+                Phone = Phone,
+                TimeZone = TimeZone,
+                TwitterId = TwitterId,
+                CreatedAt = CreatedAt,
+                UpdatedAt = UpdatedAt,
+                CustomFields = CustomFields
+            };
+            if (OtherEmails != null && OtherEmails.Count > 0)
+            {
+                foreach (var otherEmail in OtherEmails)
+                {
+                    contact.OtherEmails.Add(otherEmail);
+                }
+            }
+            if (Tags != null && Tags.Count > 0)
+            {
+                foreach (var tag in Tags)
+                {
+                    contact.Tags.Add(tag);
+                }
+            }
+            if (OtherCompanies != null && OtherCompanies.Count > 0)
+            {
+                foreach (var otherCompany in OtherCompanies)
+                {
+                    contact.OtherCompanies.Add(new FreshdeskOtherCompany() { CompanyId = otherCompany });
+                }
+            }
+            return contact;
+        }
+
+        public static FreshdeskContactFromListInternalBase<TCustomFieldObject> FromContact(FreshdeskContact<TCustomFieldObject> contact)
+        {
+            ulong? companyId;
+            if (contact.CompanyId == default(ulong))
+            {
+                companyId = null;
+            }
+            else
+            {
+                companyId = contact.CompanyId;
+            }
+            var result = new FreshdeskContactFromListInternalBase<TCustomFieldObject>
+            {
+                Active = contact.Active,
+                Address = contact.Address,
+                Avatar = contact.Avatar,
+                CompanyId = companyId,
+                ViewAllTickets = contact.ViewAllTickets,
+                Deleted = contact.Deleted,
+                Description = contact.Description,
+                Email = contact.Email,
+                Id = contact.Id,
+                JobTitle = contact.JobTitle,
+                Language = contact.Language,
+                Mobile = contact.Mobile,
+                Name = contact.Name,
+                Phone = contact.Phone,
+                TimeZone = contact.TimeZone,
+                TwitterId = contact.TwitterId,
+                CreatedAt = contact.CreatedAt,
+                UpdatedAt = contact.UpdatedAt,
+                OtherEmails = contact.OtherEmails,
+                Tags = contact.Tags,
+                CustomFields = contact.CustomFields
+            };
+
+            if (contact.OtherCompanies != null && contact.OtherCompanies.Count > 0)
+            {
+                result.OtherCompanies = new List<ulong?>();
+
+                foreach (var otherCompany in contact.OtherCompanies)
+                {
+                    result.OtherCompanies.Add(otherCompany.CompanyId);
+                }
+            }
+
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
The SearchByNameAsync method returns a simple list of objects that matches the results of the freshdesk autocomplete method and allows for easy searching rather than having to use the full Search method.

I found an issue with the original code in dbasoftwares original repo because Freshdesk returns other_companies in a different format when using the list method - it returns list of ulong rather than the normal complex FreshdeskCompany object